### PR TITLE
vue optimizations working on simple sample site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/preset-typescript": "7.27.1",
         "@babel/traverse": "7.27.4",
         "@babel/types": "7.27.6",
+        "@vue/compiler-sfc": "3.5.17",
         "axios": "^1.9.0",
         "chalk": "^5.3.0",
         "cheerio": "^1.0.0",
@@ -30,9 +31,11 @@
         "htmlparser2": "^9.1.0",
         "inquirer": "^9.2.15",
         "jsdom": "^26.1.0",
+        "magic-string": "0.30.17",
         "openai": "^4.28.4",
         "ora": "^8.0.1",
-        "prettier": "3.5.3"
+        "prettier": "3.5.3",
+        "vue-meta": "2.4.0"
       },
       "bin": {
         "cliseo": "dist/cli/cli.js"
@@ -2375,6 +2378,67 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
+      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
+      "dependencies": {
+        "@babel/parser": "^7.27.5",
+        "@vue/shared": "3.5.17",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
+      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.17",
+        "@vue/shared": "3.5.17"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
+      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
+      "dependencies": {
+        "@babel/parser": "^7.27.5",
+        "@vue/compiler-core": "3.5.17",
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/compiler-ssr": "3.5.17",
+        "@vue/shared": "3.5.17",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.17",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
+      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/shared": "3.5.17"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg=="
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3045,6 +3109,14 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -4694,8 +4766,6 @@
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -4847,7 +4917,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5344,7 +5413,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5692,7 +5760,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6271,6 +6338,14 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-meta": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-2.4.0.tgz",
+      "integrity": "sha512-XEeZUmlVeODclAjCNpWDnjgw+t3WA6gdzs6ENoIAgwO1J1d5p1tezDhtteLUFwcaQaTtayRrsx7GL6oXp/m2Jw==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/traverse": "7.27.4",
     "@babel/types": "7.27.6",
+    "@vue/compiler-sfc": "3.5.17",
     "axios": "^1.9.0",
     "chalk": "^5.3.0",
     "cheerio": "^1.0.0",
@@ -42,9 +43,11 @@
     "htmlparser2": "^9.1.0",
     "inquirer": "^9.2.15",
     "jsdom": "^26.1.0",
+    "magic-string": "0.30.17",
     "openai": "^4.28.4",
     "ora": "^8.0.1",
-    "prettier": "3.5.3"
+    "prettier": "3.5.3",
+    "vue-meta": "2.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,22 @@
+# robots.txt for cliseo
+
+# Allow all crawlers
+User-agent: *
+Allow: /
+
+# Disallow admin and private areas
+Disallow: /admin/
+Disallow: /private/
+Disallow: /api/
+Disallow: /_next/
+Disallow: /static/
+
+# Crawl-delay for specific bots
+User-agent: GPTBot
+Crawl-delay: 1
+
+User-agent: ChatGPT-User
+Crawl-delay: 1
+
+# Sitemap location
+Sitemap: https://yourdomain.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <!-- Homepage -->
+  <url>
+    <loc>https://yourdomain.com/</loc>
+    <lastmod>2025-07-26T04:30:03.122Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  
+  <!-- Common pages -->
+  <url>
+    <loc>https://yourdomain.com/about</loc>
+    <lastmod>2025-07-26T04:30:03.123Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  
+  <url>
+    <loc>https://yourdomain.com/contact</loc>
+    <lastmod>2025-07-26T04:30:03.123Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  
+  <!-- Blog section -->
+  <url>
+    <loc>https://yourdomain.com/blog</loc>
+    <lastmod>2025-07-26T04:30:03.123Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>

--- a/src/cli/commands/optimize-vue.ts
+++ b/src/cli/commands/optimize-vue.ts
@@ -1,0 +1,115 @@
+// optimizeVueComponents.ts
+import { readFileSync, writeFileSync } from 'fs';
+import path, { join } from 'path';
+import { glob } from 'glob';
+import { execSync } from 'child_process';
+
+const SEO_HEAD_BLOCK = `
+useHead({
+  title: 'Your Page Title',
+  meta: [
+    { name: 'description', content: 'Default description for this page' },
+    { property: 'og:title', content: 'Your OG Title' }
+  ],
+  link: [
+    { rel: 'canonical', href: 'https://yourdomain.com/current-page' }
+  ]
+})
+`;
+
+function isLikelyVuePageFile(filePath: string): boolean {
+
+  const normalized = filePath.replace(/\\/g, '/');
+  const base = path.basename(filePath);
+
+  // Must be in a relevant directory like pages, views, or routes
+  if (!/\/(pages|views|routes)\//.test(normalized)) {
+    return false;
+  }
+
+  // Must be a .vue file
+  if (!base.endsWith('.vue')) {
+    return false;
+  }
+
+  // Exclude generic files like App.vue, main.vue, index.vue
+  if (/^(App|main|index)\.vue$/i.test(base)) {
+    return false;
+  }
+
+  return true;
+}
+
+
+async function ensureVueMetaInstalled(projectRoot: string) {
+  const pkgPath = join(projectRoot, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  const hasVueMeta = pkg.dependencies?.['vue-meta'] || pkg.devDependencies?.['vue-meta'];
+
+  if (!hasVueMeta) {
+    console.log('📦 Installing vue-meta...');
+    execSync('npm install vue-meta', { cwd: projectRoot, stdio: 'inherit' });
+  }
+}
+
+async function injectSeoIntoVueFiles(projectRoot: string) {
+  const allFiles = await glob('src/{pages,views,routes}/**/*.vue', { cwd: projectRoot, absolute: true });
+  const files = allFiles.filter(isLikelyVuePageFile);
+
+  if (files.length === 0) {
+    console.warn('⚠️ No Vue files found in src/pages/. Skipping.');
+    return;
+  }
+
+  for (const file of files) {
+    let content = readFileSync(file, 'utf-8');
+
+    if (!content.includes('<script setup')) {
+        // No script setup tag: add one at the end with import and useHead
+        content += `
+
+<script setup>
+import { useHead } from 'vue-meta'
+
+useHead({
+title: 'Your Page Title',
+meta: [
+    { name: 'description', content: 'Default description for this page' },
+    { property: 'og:title', content: 'Your OG Title' }
+],
+link: [
+    { rel: 'canonical', href: 'https://yourdomain.com/current-page' }
+]
+})
+</script>
+`
+        writeFileSync(file, content, 'utf-8')
+        console.log(`✅ Added <script setup> and injected SEO into ${file}`)
+        continue
+    }
+
+    if (content.includes('useHead({')) continue;
+
+    if (!content.includes('import { useHead }')) {
+      content = content.replace(
+        /<script setup.*?>/,
+        match => `${match}\nimport { useHead } from 'vue-meta'`
+      );
+    }
+
+    const lines = content.split('\n');
+    const scriptStartIndex = lines.findIndex(l => l.trim().startsWith('<script setup'));
+    const scriptEndIndex = lines.findIndex((l, i) => i > scriptStartIndex && l.trim().startsWith('</script>'));
+
+    const insertIndex = scriptEndIndex === -1 ? lines.length : scriptEndIndex;
+    lines.splice(insertIndex, 0, SEO_HEAD_BLOCK);
+
+    writeFileSync(file, lines.join('\n'), 'utf-8');
+    console.log(`✅ Injected SEO metadata into ${file}`);
+  }
+}
+
+export async function optimizeVueComponents(projectRoot: string) {
+  await ensureVueMetaInstalled(projectRoot);
+  await injectSeoIntoVueFiles(projectRoot);
+}

--- a/testsites/vue/vue-sample-site/robots.txt
+++ b/testsites/vue/vue-sample-site/robots.txt
@@ -1,0 +1,22 @@
+# robots.txt for vue-sample-site
+
+# Allow all crawlers
+User-agent: *
+Allow: /
+
+# Disallow admin and private areas
+Disallow: /admin/
+Disallow: /private/
+Disallow: /api/
+Disallow: /_next/
+Disallow: /static/
+
+# Crawl-delay for specific bots
+User-agent: GPTBot
+Crawl-delay: 1
+
+User-agent: ChatGPT-User
+Crawl-delay: 1
+
+# Sitemap location
+Sitemap: https://yourdomain.com/sitemap.xml

--- a/testsites/vue/vue-sample-site/sitemap.xml
+++ b/testsites/vue/vue-sample-site/sitemap.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <!-- Homepage -->
+  <url>
+    <loc>https://yourdomain.com/</loc>
+    <lastmod>2025-07-26T04:09:22.763Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  
+  <!-- Common pages -->
+  <url>
+    <loc>https://yourdomain.com/about</loc>
+    <lastmod>2025-07-26T04:09:22.764Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  
+  <url>
+    <loc>https://yourdomain.com/contact</loc>
+    <lastmod>2025-07-26T04:09:22.764Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  
+  <!-- Blog section -->
+  <url>
+    <loc>https://yourdomain.com/blog</loc>
+    <lastmod>2025-07-26T04:09:22.764Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## PR: Vue 3 SEO Metadata Injection

Adds support for injecting SEO metadata into Vue 3 `.vue` files under `src/pages`.  
The `optimizeVueComponents` function:

- Adds `useHead()` from `vue-meta` inside `<script setup>` blocks with default SEO tags.
- Automatically inserts `<script setup>` if missing.
- Installs `vue-meta` if not found in dependencies.